### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This project is configured for GitHub Pages deployment. The build process create
    Alternatively, for GitHub Actions deployment:
    - Set the source to "GitHub Actions"
    - The build artifacts from the `dist` folder will be automatically deployed
+   - The included workflow `.github/workflows/deploy.yml` builds the site and
+     publishes the `dist` directory to the `gh-pages` branch.
 
 3. **Important Files**:
    - `.nojekyll`: Included in the `dist` folder to prevent GitHub Pages from processing the site with Jekyll


### PR DESCRIPTION
## Summary
- add a workflow to build and deploy to `gh-pages`
- document the new workflow in the README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d28599ff88329825ae2ae0289eb64